### PR TITLE
Optimize home slider image loading

### DIFF
--- a/src/components/Home/index.jsx
+++ b/src/components/Home/index.jsx
@@ -1,7 +1,10 @@
 "use client";
 import { useContext, useEffect, useState, useMemo } from "react";
 import HomeCatSlider from "@/components/HomeCatSlider";
-import HomeSlider from "@/components/HomeSlider";
+import dynamic from "next/dynamic";
+const HomeSlider = dynamic(() => import("@/components/HomeSlider"), {
+  ssr: false,
+});
 import ProductsSlider from "@/components/ProductsSlider";
 import Tabs from "@mui/material/Tabs";
 import Tab from "@mui/material/Tab";

--- a/src/components/HomeSlider/index.jsx
+++ b/src/components/HomeSlider/index.jsx
@@ -25,9 +25,11 @@ const HomeSlider = (props) => {
           }}
           className="sliderHome"
         >
-          {
-            props?.data?.length !== 0 && props?.data?.slice()?.reverse()?.map((item, index) => {
-              return (
+          {props?.data?.length !== 0 &&
+            props?.data
+              ?.slice()
+              ?.reverse()
+              ?.map((item, index) => (
                 <SwiperSlide key={index}>
                   <div className="item rounded-[10px] overflow-hidden relative">
                     <Image
@@ -36,14 +38,12 @@ const HomeSlider = (props) => {
                       src={item?.images[0]}
                       alt="Banner slide"
                       className="!w-full !h-auto"
-                      priority 
+                      priority={index === 0}
+                      loading={index === 0 ? "eager" : "lazy"}
                     />
                   </div>
                 </SwiperSlide>
-              )
-            })
-          }
-
+              ))}
         </Swiper>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- load HomeSlider dynamically to trim initial bundle
- lazy load all HomeSlider images except the first slide

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6841e9066d1c8322a560255f20696a21